### PR TITLE
Require spaces in anonymous function expression

### DIFF
--- a/languages/js/.jscsrc
+++ b/languages/js/.jscsrc
@@ -51,8 +51,9 @@
     "requireSpacesInFunctionExpression": {
         "beforeOpeningCurlyBrace": true
     },
-    "disallowSpacesInAnonymousFunctionExpression": {
-        "beforeOpeningRoundBrace": true
+    "requireSpacesInAnonymousFunctionExpression": {
+        "beforeOpeningRoundBrace": true,
+        "beforeOpeningCurlyBrace": true
     },
     "disallowSpacesInsideObjectBrackets": "all",
     "disallowSpacesInsideArrayBrackets": "all",


### PR DESCRIPTION
A space is required in an anonymous function expression.
###### Example
```
function (err, value) {

}
```